### PR TITLE
Fixed typo in tooltips.

### DIFF
--- a/plugins/locator/buttons/go-down-to-context.tid
+++ b/plugins/locator/buttons/go-down-to-context.tid
@@ -3,7 +3,7 @@ title: $:/plugins/bimlas/locator/buttons/go-down-to-context
 type: text/vnd.tiddlywiki
 
 \define node()
-  <$button tooltip="Go to context, show chidlren of this tiddler" class=<<link-button-class>> actions={{$:/plugins/bimlas/locator/actions/add-to-history}}>
+  <$button tooltip="Go to context, show children of this tiddler" class=<<link-button-class>> actions={{$:/plugins/bimlas/locator/actions/add-to-history}}>
     {{$:/plugins/bimlas/locator/buttons/context-arrow}}
   </$button>
 \end

--- a/plugins/locator/buttons/go-up-to-context.tid
+++ b/plugins/locator/buttons/go-up-to-context.tid
@@ -7,6 +7,6 @@ type: text/vnd.tiddlywiki
   {{$:/plugins/bimlas/locator/actions/remove-filters}}
 \end
 
-<$button tooltip="Go to context, show chidlren of this tiddler" class=<<link-button-class>> actions=<<actions>>>
+<$button tooltip="Go to context, show children of this tiddler" class=<<link-button-class>> actions=<<actions>>>
   {{$:/plugins/bimlas/locator/buttons/context-arrow}}
 </$button>


### PR DESCRIPTION
It's a minor thing, but I noticed that the tooltips read "chidlren" instead of "children", so I created a quick patch to correct them.